### PR TITLE
Adding a video using a youtube shortened link

### DIFF
--- a/src/interfaces/Platform/Platform.ts
+++ b/src/interfaces/Platform/Platform.ts
@@ -1,7 +1,8 @@
 import {LinkService} from "../LinkService/LinkService";
+import {PlatformType} from "./PlatformType";
 
 export interface Platform {
-    id: number;
+    id: PlatformType;
     regex: string;
     linkService: LinkService;
 }

--- a/src/interfaces/Platform/PlatformType.ts
+++ b/src/interfaces/Platform/PlatformType.ts
@@ -1,0 +1,4 @@
+export enum PlatformType {
+    YOUTUBE,
+    VIMEO
+}

--- a/src/modules/SearchBar/videoPlatforms.ts
+++ b/src/modules/SearchBar/videoPlatforms.ts
@@ -1,11 +1,17 @@
 import {Platform} from "../../interfaces/Platform/Platform";
-import {FullYouTubeLinkService} from "../../services/FullYouTubeLinkService/FullYouTubeLinkService";
+import {YouTubeLinkService} from "../../services/YouTubeLinkService/YouTubeLinkService";
+import {PlatformType} from "../../interfaces/Platform/PlatformType";
 
 const videoPlatforms: Platform[] = [
     {
-        id: 0,
+        id: PlatformType.YOUTUBE,
         regex: "^((?:https?:)?\\/\\/)?((?:www|m)\\.)?youtube.com\\/watch\\?v=([a-zA-Z0-9\\_-]+)",
-        linkService: new FullYouTubeLinkService()
+        linkService: new YouTubeLinkService()
+    },
+    {
+        id: PlatformType.YOUTUBE,
+        regex: "^((?:https?:)?\\/\\/)?((?:www|m)\\.)?youtu.be/([a-zA-Z0-9\\_-]+)",
+        linkService: new YouTubeLinkService()
     }
 ];
 

--- a/src/services/YouTubeLinkService/YouTubeLinkService.ts
+++ b/src/services/YouTubeLinkService/YouTubeLinkService.ts
@@ -2,7 +2,7 @@ import {LinkService} from "../../interfaces/LinkService/LinkService";
 import {YouTubeService} from "../YouTubeService/YouTubeService";
 import {VideoService} from "../VideoService/VideoService";
 
-export class FullYouTubeLinkService implements LinkService {
+export class YouTubeLinkService implements LinkService {
     getVideoId(url: string) {
         const platform = VideoService.getVideoPlatform(url);
         if (platform) {


### PR DESCRIPTION
Closes #4

- Add new object to video platforms that match shorten youtube link
- Change FullYouTubeLinkService to YouTubeLinkService to avoid code redundancy in short and full youtube link services
- Add an enum to differentiate the youtube and vimeo platforms