### PR TITLE
Adding a video using a Youtube video ID

### DIFF
--- a/src/modules/SearchBar/videoPlatforms.ts
+++ b/src/modules/SearchBar/videoPlatforms.ts
@@ -1,6 +1,7 @@
 import {Platform} from "../../interfaces/Platform/Platform";
 import {YouTubeLinkService} from "../../services/YouTubeLinkService/YouTubeLinkService";
 import {PlatformType} from "../../interfaces/Platform/PlatformType";
+import {YouTubeVideoIdService} from "../../services/YouTubeVideoIdService/YouTubeVideoIdService";
 
 const videoPlatforms: Platform[] = [
     {
@@ -12,6 +13,11 @@ const videoPlatforms: Platform[] = [
         id: PlatformType.YOUTUBE,
         regex: "^((?:https?:)?\\/\\/)?((?:www|m)\\.)?youtu.be/([a-zA-Z0-9\\_-]+)",
         linkService: new YouTubeLinkService()
+    },
+    {
+        id: PlatformType.YOUTUBE,
+        regex: "([a-z0-9A-Z]{11})",
+        linkService: new YouTubeVideoIdService()
     }
 ];
 

--- a/src/services/RegexService/RegexService.ts
+++ b/src/services/RegexService/RegexService.ts
@@ -1,0 +1,6 @@
+export class RegexService {
+    static getMatchingString(matchingText: string, regex: string, position: number) {
+        const matchStringArray = matchingText.match(regex);
+        return matchStringArray ? matchStringArray[position] : "";
+    }
+}

--- a/src/services/YouTubeVideoIdService/YouTubeVideoIdService.ts
+++ b/src/services/YouTubeVideoIdService/YouTubeVideoIdService.ts
@@ -3,18 +3,18 @@ import {YouTubeService} from "../YouTubeService/YouTubeService";
 import {VideoService} from "../VideoService/VideoService";
 import {RegexService} from "../RegexService/RegexService";
 
-export class YouTubeLinkService implements LinkService {
+export class YouTubeVideoIdService implements LinkService {
     getVideoId(url: string) {
         const platform = VideoService.getVideoPlatform(url);
         if (platform) {
-            return RegexService.getMatchingString(url, platform.regex, 3);
+            return RegexService.getMatchingString(url, platform.regex, 0);
         }
         return "";
     }
 
     async checkVideoLink(url: string) {
-        const videoId = this.getVideoId(url);
-        const response = await YouTubeService.getVideoDetails(videoId);
+        const youTubeVideoId = this.getVideoId(url);
+        const response = await YouTubeService.getVideoDetails(youTubeVideoId);
         return response.data['items'].length > 0;
     }
 }


### PR DESCRIPTION
Closes #5

- Add new object to video platforms that match youtube video id
- Add YouTubeVideoIdService which applies to the situation where the user gives the video id from youtube
- Add RegexService and method that return matching string with regex